### PR TITLE
Silence PyGi warnings by requiring versions before importing

### DIFF
--- a/neovim_gui/gtk_ui.py
+++ b/neovim_gui/gtk_ui.py
@@ -4,6 +4,10 @@ import math
 
 import cairo
 
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('Gdk', '3.0')
+gi.require_version('PangoCairo', '1.0')
 from gi.repository import GLib, GObject, Gdk, Gtk, Pango, PangoCairo
 
 from .screen import Screen


### PR DESCRIPTION
Fixes #10
